### PR TITLE
Fixed a small typo in readme. rosetta main dir should include /

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ python code/prepare.py --rosetta_main_dir=<path_to_rosetta_main_dir> --pdb_fn=pd
 
 >**Note**  
 > You need to specify the path to your Rosetta installation's `main` folder. It may look similar to:  
-`/Users/<username>/rosetta_bin_mac_2021.16.61629_bundle/main` 
+`/Users/<username>/rosetta_bin_mac_2021.16.61629_bundle/main/` 
 
 Additional arguments specified in this example: 
 


### PR DESCRIPTION
I saw that there was a small typo in the README file, the rosetta main directory should include a forward slash at the end, as `code/prepare.py` line 55 is:

```python
clean_pdb_script_fn = abspath(join(rosetta_main_dir, "tools/protein_tools/scripts/clean_pdb.py"))
```

I know it's a small change, totally understandable if you don't want to accept.