### PR TITLE
fixed process_run.py to match README instructions

### DIFF
--- a/code/process_run.py
+++ b/code/process_run.py
@@ -278,7 +278,7 @@ if __name__ == "__main__":
                         type=str,
                         nargs="+")
 
-    parser.add_argument("--database_fn",
+    parser.add_argument("--db_fn",
                         help="for mode 'database', the database to add the run to",
                         type=str,
                         default=None)

--- a/code/process_run.py
+++ b/code/process_run.py
@@ -254,7 +254,7 @@ def main(args):
             energize_out_dir = join(main_dir, "output", "energize_outputs")
 
             # add to database
-            add_to_database(args.database_fn, processed_run_dir, energize_out_dir)
+            add_to_database(args.db_fn, processed_run_dir, energize_out_dir)
 
         elif args.mode == "cleanup":
             # create a new condor run definition file to re-run failed jobs


### PR DESCRIPTION
In the README it's specified to use `--db_fn` for the `process_run.py` script, however the parameter specified in the `process_run.py` is `--database_fn`.

For the sake of consistency, I think that this should have been `--db_fn`.